### PR TITLE
Override Object.defineProperty to allow for proper mocking

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,14 @@
+// This is needed top stop getter/setter exports from freezing items, so that we can mock them
+const { defineProperty } = Object;
+Object.defineProperty = function (object, name, meta) {
+  if (meta.get && !meta.configurable) {
+    return defineProperty(object, name, {
+      ...meta,
+      configurable: true, // prevent freezing
+    });
+  }
+
+  return defineProperty(object, name, meta);
+};
+
 import "@testing-library/jest-dom";

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -3,9 +3,9 @@ import { render } from "@testing-library/react";
 import { useSelect } from "@wordpress/data";
 
 jest.mock("@wordpress/data", () => {
-  return {
-    useSelect: jest.fn().mockReturnValue({}),
-  };
+  const wpData = jest.requireActual("@wordpress/data");
+  Object.defineProperty(wpData, "useSelect", { value: jest.fn() });
+  return wpData;
 });
 
 describe("MyComponent", () => {


### PR DESCRIPTION
Added override for `Object.defineProperty` to allow for mocking of imports which have getters/setters